### PR TITLE
Prevent altering $rootPage->children permanently

### DIFF
--- a/MarkupSimpleNavigation.module
+++ b/MarkupSimpleNavigation.module
@@ -143,7 +143,8 @@ class MarkupSimpleNavigation extends WireData implements Module {
 		}
 
 		if($options['show_root'] && $this->iteration == 1) {
-			$children = $rootPage->children( $selector );
+			$children = new PageArray();
+			$children->add($rootPage->children( $selector ));
 			$children->prepend( $rootPage );
 		} else {
 			if($rootPage->navigationEntries && $rootPage->navigationEntries instanceof PageArray){


### PR DESCRIPTION
The module alters the root page children page array in a permanent manner when 'show_root' is set to true. After rendering the nav with that option, when you call $pages->get('/')->children at a later point, the home is included in the array. The above change fixes it.